### PR TITLE
chore: fix syntax error

### DIFF
--- a/content/feesandbribes.mdx
+++ b/content/feesandbribes.mdx
@@ -19,7 +19,7 @@ Fee rewards are distributed as accrued and can be claimed at any time. Fee rewar
 
 In addition to fee rewards, liquidity pools can receive external voter rewards from protocols or other participants (known as _incentives_). Incentives can be deposited for _whitelisted_ tokens and are distributed _only_ to voters on that pool, proportionally to their share of pool votes.
 
-These rewards are available for claim after the epoch epoch changes (Thursday 00:00 UTC), and are distributed proportionally to the voting power cast by a voter (`$veAERO`).
+These rewards are available for claim after the epoch changes (Thursday 00:00 UTC), and are distributed proportionally to the voting power cast by a voter (`$veAERO`).
 
 ## Rewards claim
 


### PR DESCRIPTION
remove duplicate word and make sentence tidy.