### PR TITLE
Add 'Launcher' and 'FAQ' links to index

### DIFF
--- a/content/index.mdx
+++ b/content/index.mdx
@@ -10,6 +10,8 @@ across the web app.
 - [Voting](voting.mdx)
 - [Fees and Incentives](feesandbribes.mdx)
 - [Relay](relay.mdx)
+- [Launcher](launcher.mdx)
+- [FAQ](faq.mdx)
 
 Misc
 


### PR DESCRIPTION
## Description
Added missing documentation links to `index.mdx` for two existing pages that were not listed:
- `launcher.mdx` - Aero Launch documentation
- `faq.mdx` - Frequently Asked Questions

## Motivation
Both `launcher.mdx` and `faq.mdx` exist in the `content/` folder but were not discoverable from the main index page. This improves documentation navigation and discoverability.

## Changes
- Added link to Launcher documentation
- Added link to FAQ documentation