### PR TITLE
docs: add official Pool Launcher contract address

### DIFF
--- a/content/security.mdx
+++ b/content/security.mdx
@@ -261,3 +261,7 @@ Pool Launcher was audited by MixBytes. The audit took place between
 - [MixBytes Audit](https://github.com/mixbytes/audits_public/tree/master/Velodrome/Pool%20Launcher)
 - [Pool Launcher Codebase](https://github.com/velodrome-finance/pool-launcher)
 - [Contracts](https://github.com/velodrome-finance/pool-launcher/tree/develop/deployment-addresses)
+
+### Contract Address
+
+- **Pool Launcher:** [`0x5077797e8B6e5A831a3194565786E45507E2F892`](https://basescan.org/address/0x5077797e8B6e5A831a3194565786E45507E2F892)


### PR DESCRIPTION
This PR adds the official Pool Launcher contract address to the Security Overview page. This address was previously only accessible via external GitHub links, and adding it here improves documentation completeness for developers.