### PR TITLE
Add Pool Launcher contract addresses to security page

### DIFF
--- a/content/security.mdx
+++ b/content/security.mdx
@@ -261,3 +261,52 @@ Pool Launcher was audited by MixBytes. The audit took place between
 - [MixBytes Audit](https://github.com/mixbytes/audits_public/tree/master/Velodrome/Pool%20Launcher)
 - [Pool Launcher Codebase](https://github.com/velodrome-finance/pool-launcher)
 - [Contracts](https://github.com/velodrome-finance/pool-launcher/tree/develop/deployment-addresses)
+
+{
+<table className="min-w-full w-full divide-y divide-accent-10 rounded-xl overflow-hidden bg-accent-0 font-mono">
+  <thead>
+    <tr>
+      <th className="px-6 py-3 text-left font-medium uppercase text-xs text-accent-50 w-2/3">Pool Launcher Contract Name</th>
+      <th className="px-6 py-3 text-left font-medium uppercase text-xs text-accent-50">Address</th>
+    </tr>
+  </thead>
+  <tbody className="divide-y divide-accent-10">
+    <tr>
+      <td className="px-6 py-4">CLLockerFactory</td>
+      <td className="px-6 py-4">
+        <a href="https://basescan.org/address/0x8BF02b8da7a6091Ac1326d6db2ed25214D812219" target="_blank">0x8BF02b8da7a6091Ac1326d6db2ed25214D812219</a>
+      </td>
+    </tr>
+    <tr>
+      <td className="px-6 py-4">CLLockerImplementation</td>
+      <td className="px-6 py-4">
+        <a href="https://basescan.org/address/0xE5123AC41655b1A5CA09B3A6BE6c7151E67C00E0" target="_blank">0xE5123AC41655b1A5CA09B3A6BE6c7151E67C00E0</a>
+      </td>
+    </tr>
+    <tr>
+      <td className="px-6 py-4">CLPoolLauncher</td>
+      <td className="px-6 py-4">
+        <a href="https://basescan.org/address/0xb9A1094D614c70B94C2CD7b4efc3A6adC6e6F4d3" target="_blank">0xb9A1094D614c70B94C2CD7b4efc3A6adC6e6F4d3</a>
+      </td>
+    </tr>
+    <tr>
+      <td className="px-6 py-4">V2LockerFactory</td>
+      <td className="px-6 py-4">
+        <a href="https://basescan.org/address/0x067b028C66f61466F66864cc01F92Afc7D99e530" target="_blank">0x067b028C66f61466F66864cc01F92Afc7D99e530</a>
+      </td>
+    </tr>
+    <tr>
+      <td className="px-6 py-4">V2LockerImplementation</td>
+      <td className="px-6 py-4">
+        <a href="https://basescan.org/address/0x11bc9051A4EE340FD182A6cA72d18eC93d92E60d" target="_blank">0x11bc9051A4EE340FD182A6cA72d18eC93d92E60d</a>
+      </td>
+    </tr>
+    <tr>
+      <td className="px-6 py-4">V2PoolLauncher</td>
+      <td className="px-6 py-4">
+        <a href="https://basescan.org/address/0xA81eEbdEb3129bf5B89AEd89EDe9eC5fB6FDE3B3" target="_blank">0xA81eEbdEb3129bf5B89AEd89EDe9eC5fB6FDE3B3</a>
+      </td>
+    </tr>
+  </tbody>
+</table>
+}


### PR DESCRIPTION
## Summary
- Adds the 6 Pool Launcher contract addresses to the security page under the Pool Launcher section
- Includes both Slipstream (CL) and V2 launcher contracts: CLLockerFactory, CLLockerImplementation, CLPoolLauncher, V2LockerFactory, V2LockerImplementation, V2PoolLauncher
- Addresses sourced from [velodrome-finance/pool-launcher deployment-addresses/base.json](https://github.com/velodrome-finance/pool-launcher/tree/develop/deployment-addresses)

Resolves the missing contract addresses flagged by @0xmethodic.