### PR TITLE
docs: Add Spraay Protocol batch payment integration guide

### DIFF
--- a/content/spraay.mdx
+++ b/content/spraay.mdx
@@ -1,0 +1,42 @@
+# Batch Payments with Spraay Protocol
+
+## Overview
+
+[Spraay Protocol](https://spraay.app) is a batch payment protocol on Base that lets you send ERC20 tokens (including AERO, USDC, WETH, and any standard ERC20) to multiple recipients in a single transaction. Instead of executing N separate transfers, Spraay batches them into one on-chain call — saving gas and time.
+
+## Use Cases for Aerodrome Ecosystem
+
+### Reward & Incentive Distribution
+
+Protocols and DAOs participating in Aerodrome governance often need to distribute tokens to voters, LPs, or community members. Spraay handles this in one transaction:
+
+- Distribute AERO incentives to multiple liquidity providers
+- Send bribe tokens to voters across multiple gauges
+- Pay protocol contributors and team members in USDC or AERO
+
+### Community Airdrops
+
+Projects launching liquidity pools on Aerodrome can use Spraay to airdrop their tokens to target wallet addresses in bulk — useful for early LP incentive programs, community rewards, or marketing campaigns.
+
+### DAO Treasury Operations
+
+Teams managing Aerodrome-related DAOs can use Spraay for treasury disbursements: grant payments, bounty payouts, and recurring contributor compensation — all batched into single transactions for lower gas costs and cleaner accounting.
+
+## How It Works
+
+1. **Connect your wallet** on [spraay.app](https://spraay.app)
+2. **Select the token** you want to distribute (AERO, USDC, or any ERC20 on Base)
+3. **Enter recipients** — paste addresses and amounts, or upload a CSV
+4. **Approve & send** — one approval + one batch transaction
+
+Spraay charges a 0.3% protocol fee per batch transaction.
+
+## Contract Details
+
+Spraay is deployed on Base mainnet and 14 other chains. For contract addresses and developer integration details, visit the [Spraay documentation](https://docs.spraay.app).
+
+## Links
+
+- Website: [spraay.app](https://spraay.app)
+- Documentation: [docs.spraay.app](https://docs.spraay.app)
+- GitHub: [github.com/plagtech/spraay-app](https://github.com/plagtech/spraay-app)


### PR DESCRIPTION
### Summary

Adds documentation for integrating Spraay Protocol's batch payment tooling with Aerodrome Finance. Spraay enables single-transaction ERC20 distributions to multiple recipients on Base — useful for protocols, DAOs, and teams in the Aerodrome ecosystem that need to distribute AERO rewards, bribe payments, LP incentives, or run ERC20 airdrops.

### Context

- **Spraay Protocol** ([spraay.app](https://spraay.app)) is a multi-chain batch payment protocol deployed on Base and 14 other chains
- Recently merged into **Google ADK** (Agent Development Kit) as a core payment integration — [PR #95](https://github.com/google/adk-python-community/pull/95)
- Production-proven on Base mainnet with live revenue from batch payment tooling

### What This Adds

A new help content page under `/content/` explaining how Aerodrome ecosystem participants can use Spraay for:

1. **Batch AERO/ERC20 distributions** — Send tokens to hundreds of addresses in a single transaction
2. **Bribe distribution** — Protocols bribing multiple gauges can batch their bribe deposits
3. **Community airdrops** — Projects launching on Aerodrome pools can airdrop tokens to LPs in bulk
4. **Team/contributor payments** — DAOs and teams paying contributors in USDC/AERO via batch

### Links

- Spraay on Base: [spraay.app](https://spraay.app)
- Spraay Contracts (Base): [GitHub](https://github.com/plagtech/spraay-app)
- Google ADK Integration: [Merged PR #95](https://github.com/google/adk-python-community/pull/95)